### PR TITLE
Always display all Quick Access items

### DIFF
--- a/src/VisualJsonEditor/Views/MainWindow.xaml
+++ b/src/VisualJsonEditor/Views/MainWindow.xaml
@@ -12,7 +12,7 @@
                      xmlns:models="clr-namespace:VisualJsonEditor.Models"
                      mc:Ignorable="d" Title="{x:Static localization:Strings.HeaderMainWindow}" 
                      Height="600" Width="700" MinWidth="400" MinHeight="400" Background="LightGray"
-                     WindowStartupLocation="CenterScreen">
+                     WindowStartupLocation="CenterScreen" ContentRendered="RibbonWindow_ContentRendered">
 
     <Window.Resources>
         <viewModels:MainWindowModel x:Key="ViewModel" />

--- a/src/VisualJsonEditor/Views/MainWindow.xaml.cs
+++ b/src/VisualJsonEditor/Views/MainWindow.xaml.cs
@@ -40,16 +40,6 @@ namespace VisualJsonEditor.Views
 
             Closing += OnWindowClosing;
 
-            // TODO: How to implement this
-            //Loaded += delegate
-            //{
-            //    foreach (QuickAccessMenuItem menuItem in Ribbon.QuickAccessItems)
-            //    {
-            //        if (!Ribbon.IsInQuickAccessToolBar(menuItem))
-            //            Ribbon.AddToQuickAccessToolBar(menuItem);
-            //    }
-            //};
-
 #if DEBUG
             if (Debugger.IsAttached)
                 Dispatcher.InvokeAsync(delegate { Model.OpenDocumentAsync(@"Samples/Sample.json"); });
@@ -164,6 +154,16 @@ namespace VisualJsonEditor.Views
         private void OnOpenDocument(object sender, RoutedEventArgs e)
         {
             ((Backstage)Ribbon.Menu).IsOpen = false;
+        }
+
+        private void RibbonWindow_ContentRendered(object sender, System.EventArgs e)
+        {
+            // Force to display all Quick Access items
+            foreach (QuickAccessMenuItem menuItem in Ribbon.QuickAccessItems)
+            {
+                if (!Ribbon.IsInQuickAccessToolBar(menuItem))
+                    Ribbon.AddToQuickAccessToolBar(menuItem);
+            }
         }
     }
 }


### PR DESCRIPTION
I noticed this TODO in the code: 
```
// TODO: How to implement this
//Loaded += delegate
//{
//    foreach (QuickAccessMenuItem menuItem in Ribbon.QuickAccessItems)
//    {
//        if (!Ribbon.IsInQuickAccessToolBar(menuItem))
//            Ribbon.AddToQuickAccessToolBar(menuItem);
//    }
//};
```

So I simply put this code into the [`ContentRendered` event](https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.contentrendered?view=netframework-4.8). It works as expected.