### PR TITLE
Handle contentEncoding base64

### DIFF
--- a/src/VisualJsonEditor/Models/JsonPropertyModel.cs
+++ b/src/VisualJsonEditor/Models/JsonPropertyModel.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Text;
 using MyToolkit.Model;
 using NJsonSchema;
 
@@ -54,10 +55,15 @@ namespace VisualJsonEditor.Models
             }
         }
 
-        /// <summary>Gets the contentEncoding value. </summary>
-        public bool IsBase64ContentEncoding
+        /// <summary>Indicates if this value is base64 encoded. </summary>
+        public bool IsBase64String
         {
-            get { return GetContentEncoding == "base64"; }
+            get
+            {
+                return Schema.Type == JsonObjectType.String && 
+                    (GetContentEncoding == "base64"
+                     || Schema.Format == JsonFormatStrings.Byte);
+            }
         }
 
         /// <summary>Gets or sets the value of the property. </summary>
@@ -67,7 +73,7 @@ namespace VisualJsonEditor.Models
             {
                 if (Parent.ContainsKey(Name))
                 {
-                    return IsBase64ContentEncoding
+                    return IsBase64String
                         ? Base64Decode(Parent[Name].ToString())
                         : Parent[Name];
                 }
@@ -78,7 +84,7 @@ namespace VisualJsonEditor.Models
             }
             set
             {
-                Parent[Name] = IsBase64ContentEncoding 
+                Parent[Name] = IsBase64String 
                     ? Base64Encode(value.ToString()) 
                     : value;
 
@@ -96,8 +102,8 @@ namespace VisualJsonEditor.Models
         /// <summary>Encode a string in Base64. </summary>
         private static string Base64Encode(string plainText)
         {
-            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
-            return System.Convert.ToBase64String(plainTextBytes);
+            var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
+            return Convert.ToBase64String(plainTextBytes);
         }
 
         /// <summary>Decode a string in Base64. </summary>
@@ -105,8 +111,8 @@ namespace VisualJsonEditor.Models
         {
             try
             {
-                var base64EncodedBytes = System.Convert.FromBase64String(base64EncodedData);
-                return System.Text.Encoding.UTF8.GetString(base64EncodedBytes);
+                var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
+                return Encoding.UTF8.GetString(base64EncodedBytes);
             }
             catch(Exception)
             {

--- a/src/VisualJsonEditor/Samples/Sample.json
+++ b/src/VisualJsonEditor/Samples/Sample.json
@@ -1,5 +1,6 @@
 ﻿{
   "StringValue": "a",
+  "StringValueEncodedBase64": "dGVzdA==",
   "BoolValue": false,
   "NumberValue": 2.3,
   "DateTimeValue": "2014-08-13T21:00:00",

--- a/src/VisualJsonEditor/Samples/Sample.json
+++ b/src/VisualJsonEditor/Samples/Sample.json
@@ -1,6 +1,6 @@
 ﻿{
   "StringValue": "a",
-  "StringValueEncodedBase64": "dGVzdA==",
+  "StringValueFormatByte": "dGVzdA==",
   "BoolValue": false,
   "NumberValue": 2.3,
   "DateTimeValue": "2014-08-13T21:00:00",

--- a/src/VisualJsonEditor/Samples/Sample.schema.json
+++ b/src/VisualJsonEditor/Samples/Sample.schema.json
@@ -17,10 +17,9 @@
       "type": "string",
       "default": "n/a"
     },
-    "StringValueEncodedBase64": {
+    "StringValueFormatByte": {
       "type": "string",
-      "default": "n/a",
-      "contentEncoding": "base64"
+      "format": "byte"
     },
     "BoolValue": {
       "type": "boolean"
@@ -48,7 +47,7 @@
     "EnumValue": {
       "type": "string",
       "enum": [ "one", "two", "three" ],
-      "x-enumNames": ["One", "Two", "Three"]
+      "x-enumNames": [ "One", "Two", "Three" ]
     },
     "Test": {
       "type": "object",

--- a/src/VisualJsonEditor/Samples/Sample.schema.json
+++ b/src/VisualJsonEditor/Samples/Sample.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "default": "n/a"
     },
+    "StringValueEncodedBase64": {
+      "type": "string",
+      "default": "n/a",
+      "contentEncoding": "base64"
+    },
     "BoolValue": {
       "type": "boolean"
     },


### PR DESCRIPTION
Implements #29 

Handle `contentEncoding` (`base64` only) property as defined in: https://json-schema.org/understanding-json-schema/reference/non_json_data.html
