### PR TITLE
Add ability to specify schema location in a "_schema" property in the document

### DIFF
--- a/src/VisualJsonEditor/Models/JsonObjectModel.cs
+++ b/src/VisualJsonEditor/Models/JsonObjectModel.cs
@@ -65,6 +65,23 @@ namespace VisualJsonEditor.Models
             return FromJson((JObject)json, schema);
         }
 
+        /// <summary> Checks the JSON data for a property called "_schema" </summary>
+        /// <param name="filePath">The JSON document file path. </param>
+        /// <returns>The path to the schema file if one is defined as a document property. </returns>
+        public static string GetSchemaProperty(string filePath)
+        {
+            JToken schemaToken;
+
+            var json = (JObject)JsonConvert.DeserializeObject(File.ReadAllText(filePath, Encoding.UTF8));
+
+            if (!json.TryGetValue("$schema", out schemaToken))
+                return null;
+
+            var relativeSchemaPath = ((JValue)schemaToken).Value as string;
+            relativeSchemaPath = relativeSchemaPath.Replace('/', Path.DirectorySeparatorChar);
+            return Path.Combine(Path.GetDirectoryName(filePath), relativeSchemaPath);
+        }
+
         /// <summary>Creates a <see cref="JsonObjectModel"/> from the given <see cref="JObject"/> and <see cref="JsonSchema4"/>. </summary>
         /// <param name="obj">The <see cref="JObject"/>. </param>
         /// <param name="schema">The <see cref="JsonSchema4"/>. </param>


### PR DESCRIPTION
**Use Case**
We have multiple JSON documents that share the same schema. 
Instead of always prompting the user to select the schema file it would be useful if the document could point to its own schema.

**Change Proposed**
This PR allows a document to specify a `_schema` property at the root of the JSON containing a relative path to the schema. 
Relative paths are supported so `"myschema.json"` and `"../../schemas/myschema.json"` would be valid examples.

As a side effect of this change I also set the `SaveAsync(bool saveSchema)` flag to use the `saveAs` flag so the schema is only persisted when the user is doing a 'Save As' operation   