### PR TITLE
Open Sample.json file on first start only if not missing

### DIFF
--- a/src/VisualJsonEditor/Views/MainWindow.xaml.cs
+++ b/src/VisualJsonEditor/Views/MainWindow.xaml.cs
@@ -8,6 +8,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
@@ -97,7 +98,12 @@ namespace VisualJsonEditor.Views
             if (_configuration.IsFirstStart)
             {
                 _configuration.IsFirstStart = false;
-                await Model.OpenDocumentAsync("Samples/Sample.json", true);
+
+                var sampleJsonPath = "Samples/Sample.json";
+                if (File.Exists(sampleJsonPath))
+                {
+                    await Model.OpenDocumentAsync(sampleJsonPath, true);
+                }
             }
         }
 


### PR DESCRIPTION
If Sample.json is missing on first launch, an exception is thrown and never shown and the application doesn't even start (this is due to another bug that will be fixed in another PR).

For now, I'm simply adding a file check before opening the sample.