### PR TITLE
Use Shutdown() instead of Close() to terminate the application

### DIFF
--- a/src/VisualJsonEditor/Views/MainWindow.xaml.cs
+++ b/src/VisualJsonEditor/Views/MainWindow.xaml.cs
@@ -134,9 +134,9 @@ namespace VisualJsonEditor.Views
                     return;
             }
 
-            Closing -= OnWindowClosing;
             SaveConfiguration();
-            await Dispatcher.InvokeAsync(Close);
+
+            Application.Current.Shutdown();
         }
 
         private void OnShowAboutWindow(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Calling Close on MainWindow is sometimes not sufficient to properly close the application.

I couldn't reproduce it consistently, but several time closing the app would not stop the debugger in Visual Studio.