### PR TITLE
HandleException can sometime fails at app start due to MainWindow not available yet

### DIFF
--- a/src/VisualJsonEditor/ViewModels/MainWindowModel.cs
+++ b/src/VisualJsonEditor/ViewModels/MainWindowModel.cs
@@ -217,7 +217,20 @@ namespace VisualJsonEditor.ViewModels
         /// <param name="exception">The exception. </param>
         public override void HandleException(Exception exception)
         {
-            ExceptionBox.Show(Strings.MessageErrorTitle, exception, Application.Current.MainWindow);
+            try
+            {
+                if (Application.Current.MainWindow != null)
+                {
+                    ExceptionBox.Show(Strings.MessageErrorTitle, exception, Application.Current.MainWindow);
+                    return;
+                }
+            }
+            catch
+            {
+                // Ignore any exception here
+            }
+
+            MessageBox.Show(exception.Message, Strings.MessageErrorTitle);
         }
 
         private async Task CreateDocumentAsync()


### PR DESCRIPTION
If `MainWindow` not available, or an exception is thrown by `ExceptionBox.Show`, then we fallback on `MessageBox.Show` as a last resort.
